### PR TITLE
ci: update paths, content permission, pull version from package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,14 @@ permissions:
 
 on:
   # Only run when a pull request is merged into the main branch
-  #pull_request:
-  #  types: [closed]
-  #  branches: [main]
-  # FIXME DEBUG: Allow manual trigger for testing, remove before merging to main
-  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
   # Build the latest master, version it, and create a release
   build-and-release:
-    # if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: self-hosted
 
     steps:

--- a/README.md
+++ b/README.md
@@ -14,18 +14,23 @@ This project uses `yarn` as a package manager but swapping in `npm` should work 
 
 ## Deploying from a Release
 
+[![Release Build](https://github.com/Festivus-Cortex/norstep4700.com/actions/workflows/release.yml/badge.svg)](https://github.com/Festivus-Cortex/norstep4700.com/actions/workflows/release.yml)
+
 Releases are published on GitHub via CI whenever a pull request to the `main` branch is approved. This is built in standalone mode with `next.js` so all dependencies are rolled into the release except `node.js`. On a machine with `node.js` installed, running `node {PATH_TO_RELEASE}/server.js` will start the server on port 3000.
 
 For production use, using a proxy like `nginx` to host the incoming traffic of `https` is recommended. Using `pm2` to help manage the node process is helpful also.
 
 ## Future Considerations
 
-- Audio Visual WOW Factor
-- CI Improvements
-  - Pulling version number for releases
-  - Automated Deployment
-  - Linting?
-- General commenting and clean up
+- Critical Items
+
+  - Audio Visual WOW Factor
+
+- Nice To Have
+  - CI/CD Improvements
+    - Automated Deployment
+    - Docker Images
+  - More commenting including some templated areas
 
 ## Template
 


### PR DESCRIPTION
Updates the release ci workflow to correct pathing and permissions. This also should parse the published version number from the `package.json` and apply it to the release.

I was struggling to test this in a branch before hand. Going to push this work that has solid steps before trying to dive further into potential debug workflows in non-default branches.

This also updates the `README` to update the future considerations and add the release workflow status badge.