### PR TITLE
ci: set up ssh to run as bot user

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,21 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Set up SSH for CI Bot
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.CI_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+        shell: bash
+
+      - name: Configure git to use SSH
+        run: |
+          git config --global user.name "Norstep-CI"
+          git config --global user.email "admin@norstep4700.com"
+          git remote set-url origin git@github.com:Festivus-Cortex/norstep4700.com.git
+        shell: bash
+
       - name: Checkout main branch
         uses: actions/checkout@v4
         with:
@@ -35,8 +50,6 @@ jobs:
       - name: Increment Package Version
         run: |
           cd ${{env.basepath}}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           yarn version --patch --no-git-tag-version
           git add package.json
           git commit -m "chore: bump version [skip ci]"
@@ -74,6 +87,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./norstep4700-portfolio.zip
+          asset_path: /norstep4700-portfolio.zip
           asset_name: norstep4700-portfolio.zip
           asset_content_type: application/zip


### PR DESCRIPTION
Set up ssh for a bot user to run jobs as an authenticated user. This should allow for secure running of organization jobs while managing the private key as an encrypted gitlab secret. Having a CI user allows it to be assigned to `RuleSets` and in this case allows a direct commit of version updates with out a separate pull request.