### PR TITLE
ci: put previously copied hidden files in archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           cp -r ${{env.basepath}}/public/. /release/public/
           cp -r ${{env.basepath}}/.next/static/. /release/.next/static/
           cd /release
-          zip -r ../norstep4700-portfolio.zip ./*
+          zip -r ../norstep4700-portfolio.zip .
         shell: bash
 
       - name: Get Package Version


### PR DESCRIPTION
The previous PR ensured hidden files and folders were copied into the release directory in the runner workspace. However I forgot to update the zip command itself to copy hidden files and folders.