### PR TITLE
ci: remove bad/unnecessary git config step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           git config --global user.name "Norstep-CI"
           git config --global user.email "admin@norstep4700.com"
-          git remote set-url origin git@github.com:Festivus-Cortex/norstep4700.com.git
         shell: bash
 
       - name: Checkout main branch


### PR DESCRIPTION
When refreshing an action runner an error popped up relating when trying to update a git remote as it did not exist yet. This had succeeded before as the repository was cached. Upon further research I think the command is not needed anyway.