### PR TITLE
ci: update base path to reflect updated runner setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release Build
 
 env:
-  # The checkout action checks out to path /tmp/runner/work/norstep4700.com/norstep4700.com by default
-  basepath: /tmp/runner/work/norstep4700.com/norstep4700.com
+  # The runner checks out to path /opt/actions-runner/_work/norstep4700.com/norstep4700.com by default
+  basepath: /opt/actions-runner/_work/norstep4700.com/norstep4700.com
 
 permissions:
   contents: write


### PR DESCRIPTION
Due to the recent issues with out of date node.js on the ci runner setup I had to make some upgrades.

I swapped out to a custom docker solution running the github actions runner versus a base image that utilized older Linux versions. While updating this I also the default working directory and need to reflect this here.

In the future it would be best to optimize this in a way that is more relative pathed and more "bullet proof".