### PR TITLE
chore: bump Next.js to 15.5.15

### DIFF
--- a/docs/next-upgrade-research-2026-05-06.md
+++ b/docs/next-upgrade-research-2026-05-06.md
@@ -1,0 +1,74 @@
+# Next.js Upgrade Research - 2026-05-06
+
+## Recommendation
+
+Do not jump `Festivus-Cortex/norstep4700.com` straight to Next 16 as the first production fix. It is technically realistic, but risk is medium-high right now because the repo has a custom `webpack` config for `pdfjs-dist`, mixed App Router plus Pages API routes, no working lint gate, and a standalone self-hosted release flow.
+
+Best immediate target: `next@15.5.15` and `@next/mdx@15.5.15`. The repo was already on `15.5.14`, which is above the December 2025 RSC security floor for the 15.5 line, but `15.5.15` is the current 15.x backport tag on npm as of this research.
+
+## Repo State Inspected
+
+- Repo path: `/repos/norstep4700.com`
+- Commit: `cfd94def10030e45fe1d0613a1e76b26cb129377`
+- Current stack before patch:
+  - `next`: `15.5.14`
+  - `@next/mdx`: `15.5.14`
+  - `react` / `react-dom`: `19.1.1`
+  - Yarn `4.0.1`, `nodeLinker: node-modules`
+  - Node on local host: `24.14.0`
+- Routing:
+  - App Router under `src/app`
+  - Pages API routes under `src/pages/api`
+- Config:
+  - `output: "standalone"`
+  - Custom server-side webpack alias for `pdfjs-dist`
+  - `lint` script still uses deprecated `next lint`
+
+## Baseline Findings
+
+- `yarn build` completed successfully on `next@15.5.14`.
+- Build printed: `ESLint must be installed in order to run during builds`.
+- `yarn lint` failed because `next lint` is deprecated and `eslint` is missing.
+
+## Next 16 Risks That Matter
+
+- Next 16 requires Node `>=20.9.0`; verify the self-hosted GitHub runner and production host before upgrading.
+- Next 16 uses Turbopack by default for `next dev` and `next build`; a project with a custom webpack config will fail unless it migrates to Turbopack config or opts out with `next build --webpack`.
+- Next 16 removes `next lint`; lint must be run via ESLint or another tool directly.
+- Next 16 fully removes synchronous dynamic request API compatibility. This repo already appears migrated for dynamic `params`, but should still run codemods/typegen checks.
+- React should be moved from `19.1.1` to current `19.2.x` during a Next 16 attempt only after checking `react-pdf`, `next-mdx-remote`, MDX, and custom Once UI components.
+- Browser smoke coverage is important for work detail pages, resume PDF rendering, gallery/images, route transitions, and audio pages.
+
+## Recommended Migration Plan
+
+1. Low-risk security patch now:
+   - Upgrade `next` and `@next/mdx` to `15.5.15`.
+   - Keep React at `19.1.1`.
+   - Run install, build, local server smoke checks.
+
+2. Restore lint:
+   - Replace `next lint` with ESLint CLI using the official codemod or a manual migration.
+   - Install the missing ESLint packages.
+   - Decide whether to keep `.eslintrc.json` temporarily or migrate to flat config.
+
+3. Prepare for Next 16:
+   - Verify CI and production Node are `>=20.9.0`.
+   - Audit and resolve the `pdfjs-dist` webpack alias.
+   - Run async request API checks and `next typegen`.
+   - Confirm no hidden `middleware`, AMP, runtime config, unstable APIs, or parallel route slot requirements.
+
+4. Conservative Next 16 attempt:
+   - Upgrade to latest stable Next 16, matching `@next/mdx`, React, React DOM, and React types.
+   - Start production builds with `next build --webpack` if the `pdfjs-dist` alias still exists.
+   - Validate standalone release artifact and route behavior.
+
+5. Ambitious follow-up:
+   - Remove the webpack dependency and migrate fully to Turbopack-compatible config.
+   - Re-test standalone build, MDX, Sass, `react-pdf`, and runtime pages.
+
+## Sources
+
+- Next 16 upgrade guide: https://nextjs.org/docs/app/guides/upgrading/version-16
+- Next 15 upgrade guide: https://nextjs.org/docs/app/guides/upgrading/version-15
+- Dynamic APIs migration note: https://nextjs.org/docs/messages/sync-dynamic-apis
+- Next.js security update, 2025-12-11: https://nextjs.org/blog/security-update-2025-12-11

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "dependencies": {
     "@floating-ui/react-dom": "2.1.6",
     "@mdx-js/loader": "3.1.1",
-    "@next/mdx": "15.5.14",
+    "@next/mdx": "15.5.15",
     "classnames": "2.5.1",
     "cookie": "1.0.2",
     "gray-matter": "4.0.3",
-    "next": "15.5.14",
+    "next": "15.5.15",
     "next-mdx-remote": "6.0.0",
     "postcss": "8.4.39",
     "postcss-preset-env": "9.5.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,16 +1152,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/env@npm:15.5.14"
-  checksum: b5978e18d8ca31c8bf2d43966cddf7067faa11e660ca230ec28e4ca1faa363e71baffa32009c02675535f62b81de34e81f8752402a61ab6fd8f9da6022b50b4f
+"@next/env@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/env@npm:15.5.15"
+  checksum: f22ceea51866896ba0b981c74283b4637b109100efa3a3b5ed2cd0943fb7e0434fb686185a33c6dee2ede4801a4e071b6e50526bbff54cdbdc0973dfd149883f
   languageName: node
   linkType: hard
 
-"@next/mdx@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/mdx@npm:15.5.14"
+"@next/mdx@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/mdx@npm:15.5.15"
   dependencies:
     source-map: "npm:^0.7.0"
   peerDependencies:
@@ -1172,62 +1172,62 @@ __metadata:
       optional: true
     "@mdx-js/react":
       optional: true
-  checksum: 6396be20f6a63fd0be2cd299739f6a69fc47226b43d10193470c7711b6d7369d3358a67b73c14a8ca556b636d98f54b2feb9cb7edc7c9276852dec9da015b633
+  checksum: 6bea610eea0d4c9e25de38c402d8447dd742321fd57a1bc6e35c4f889a406e062b4815cfb4e26e3de198c6ea39c5778a0a77a830ebe05f38dcaeaabe4e485852
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-darwin-arm64@npm:15.5.14"
+"@next/swc-darwin-arm64@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-darwin-arm64@npm:15.5.15"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-darwin-x64@npm:15.5.14"
+"@next/swc-darwin-x64@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-darwin-x64@npm:15.5.15"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-linux-arm64-gnu@npm:15.5.14"
+"@next/swc-linux-arm64-gnu@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-arm64-gnu@npm:15.5.15"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-linux-arm64-musl@npm:15.5.14"
+"@next/swc-linux-arm64-musl@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-arm64-musl@npm:15.5.15"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-linux-x64-gnu@npm:15.5.14"
+"@next/swc-linux-x64-gnu@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-x64-gnu@npm:15.5.15"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-linux-x64-musl@npm:15.5.14"
+"@next/swc-linux-x64-musl@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-x64-musl@npm:15.5.15"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-win32-arm64-msvc@npm:15.5.14"
+"@next/swc-win32-arm64-msvc@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-win32-arm64-msvc@npm:15.5.15"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:15.5.14":
-  version: 15.5.14
-  resolution: "@next/swc-win32-x64-msvc@npm:15.5.14"
+"@next/swc-win32-x64-msvc@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-win32-x64-msvc@npm:15.5.15"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2987,19 +2987,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:15.5.14":
-  version: 15.5.14
-  resolution: "next@npm:15.5.14"
+"next@npm:15.5.15":
+  version: 15.5.15
+  resolution: "next@npm:15.5.15"
   dependencies:
-    "@next/env": "npm:15.5.14"
-    "@next/swc-darwin-arm64": "npm:15.5.14"
-    "@next/swc-darwin-x64": "npm:15.5.14"
-    "@next/swc-linux-arm64-gnu": "npm:15.5.14"
-    "@next/swc-linux-arm64-musl": "npm:15.5.14"
-    "@next/swc-linux-x64-gnu": "npm:15.5.14"
-    "@next/swc-linux-x64-musl": "npm:15.5.14"
-    "@next/swc-win32-arm64-msvc": "npm:15.5.14"
-    "@next/swc-win32-x64-msvc": "npm:15.5.14"
+    "@next/env": "npm:15.5.15"
+    "@next/swc-darwin-arm64": "npm:15.5.15"
+    "@next/swc-darwin-x64": "npm:15.5.15"
+    "@next/swc-linux-arm64-gnu": "npm:15.5.15"
+    "@next/swc-linux-arm64-musl": "npm:15.5.15"
+    "@next/swc-linux-x64-gnu": "npm:15.5.15"
+    "@next/swc-linux-x64-musl": "npm:15.5.15"
+    "@next/swc-win32-arm64-msvc": "npm:15.5.15"
+    "@next/swc-win32-x64-msvc": "npm:15.5.15"
     "@swc/helpers": "npm:0.5.15"
     caniuse-lite: "npm:^1.0.30001579"
     postcss: "npm:8.4.31"
@@ -3042,7 +3042,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: ea42e93e3f3218b6eace754c29deb72cdf10545186a5c2c688291276777c86c3097eadf774e60bbca02e7e9260f5255c1f5053879a19adfd796bada3d7dcf68b
+  checksum: 580750feebdf3035478816dcd819d216193ea0873b1f2844790b271235790129b5e8364499256a825d9b493baeddf94a39d05691f1b17ae418f39571a2381bbc
   languageName: node
   linkType: hard
 
@@ -3100,7 +3100,7 @@ __metadata:
     "@csstools/postcss-global-data": "npm:^2.1.1"
     "@floating-ui/react-dom": "npm:2.1.6"
     "@mdx-js/loader": "npm:3.1.1"
-    "@next/mdx": "npm:15.5.14"
+    "@next/mdx": "npm:15.5.15"
     "@types/cookie": "npm:^0.6.0"
     "@types/node": "npm:^20"
     "@types/react": "npm:^19.1.15"
@@ -3108,7 +3108,7 @@ __metadata:
     classnames: "npm:2.5.1"
     cookie: "npm:1.0.2"
     gray-matter: "npm:4.0.3"
-    next: "npm:15.5.14"
+    next: "npm:15.5.15"
     next-mdx-remote: "npm:6.0.0"
     postcss: "npm:8.4.39"
     postcss-custom-media: "npm:^10.0.7"


### PR DESCRIPTION
## Summary
- bump `next` from `15.5.14` to `15.5.15`
- bump `@next/mdx` from `15.5.14` to `15.5.15`
- add handoff research doc for the Next 16 investigation and migration options

## Why
- apply the low-risk security patch first while we evaluate a larger Next 16 upgrade separately

## Validation
- `COREPACK_HOME=/home/user/.openclaw/runtime/corepack yarn install --immutable`
- `COREPACK_HOME=/home/user/.openclaw/runtime/corepack yarn build`
- smoke-checked: `/`, `/about`, `/work`, `/resume`, `/gallery`, `/license`, `/blog`
- smoke-checked work pages:
  - `/work/av-the-game`
  - `/work/customizing-portfolio-template-instance`
  - `/work/ems-eschedule`
  - `/work/extras`
  - `/work/mahigaming`
- smoke-checked `/api/audio-config`

## Notes
- baseline lint issue still exists: `next lint` is deprecated and `eslint` is not installed
- `/og` route appears to be a separate existing issue and was not changed as part of this PR
- research handoff added at `docs/next-upgrade-research-2026-05-06.md`
