### PR TITLE
fix(ci): skip Yarn resolution check for Next PostCSS pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,11 @@ jobs:
           ssh-key: ${{ secrets.CI_SSH_KEY }}
 
       - name: Install dependencies
-        env:
-          YARN_ENABLE_HARDENED_MODE: "0"
         run: |
           yarn --version
-          yarn install --immutable
+          # TODO: Remove --no-check-resolutions once stable Next.js releases stop pinning postcss 8.4.31 internally.
+          # The lockfile resolves postcss to the patched version, but Yarn's CI resolution check rejects that override.
+          yarn install --immutable --no-check-resolutions
 
       - name: Increment Package Version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
           ssh-key: ${{ secrets.CI_SSH_KEY }}
 
       - name: Install dependencies
+        env:
+          YARN_ENABLE_HARDENED_MODE: "0"
         run: |
           yarn --version
           yarn install --immutable


### PR DESCRIPTION
## Summary
- keeps release installs immutable
- uses `yarn install --immutable --no-check-resolutions` instead of disabling Yarn hardened mode globally
- documents the workaround in the workflow with a TODO to remove it once stable Next.js stops pinning `postcss@8.4.31`

## Context
Next.js stable releases still pin `postcss@8.4.31` internally, while this repo's lockfile resolves PostCSS to `8.5.10` for `GHSA-qx2v-qp2m-jg93`. Yarn's GitHub Actions resolution check rejects that exact dependency override even though the immutable install is otherwise valid.

Upstream research from the PR discussion:
- vercel/next.js#93288 merged on April 29, 2026 and bumps bundled PostCSS to `8.5.10`: https://github.com/vercel/next.js/pull/93288
- npm metadata shows the fix is present in `next@16.3.0-canary.6` and newer canaries
- stable `next@15.5.18` and `next@16.2.6` still publish `postcss: 8.4.31`
- a Next maintainer stated they do not plan to backport this because they do not consider it a practical vulnerability for Next.js users: https://github.com/vercel/next.js/issues/93234#issuecomment-4386799149
- the stable-release audit noise is still being discussed in vercel/next.js#93604: https://github.com/vercel/next.js/issues/93604

## Verification
- `corepack yarn install --immutable --no-check-resolutions`